### PR TITLE
(GH-348) Fix build path mishandle

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -49,6 +49,8 @@ func (bc *BuildCommand) preExecute(cmd *cobra.Command, args []string) error {
 		bc.SourceDir = wd
 	}
 
+	bc.SourceDir = filepath.Clean(bc.SourceDir)
+
 	if bc.TargetDir == "" {
 		bc.TargetDir = filepath.Join(wd, "pkg")
 	}

--- a/cmd/build/build_test.go
+++ b/cmd/build/build_test.go
@@ -39,13 +39,19 @@ func TestCreateBuildCommand(t *testing.T) {
 		{
 			name:              "uses sourcedir, targetdir when passed in",
 			args:              []string{"--sourcedir", "/path/to/template", "--targetdir", "/path/to/output"},
-			expectedSourceDir: "/path/to/template",
+			expectedSourceDir: filepath.Clean("/path/to/template"),
 			expectedTargetDir: "/path/to/output",
 		},
 		{
 			name:              "Sets correct defaults if sourcedir and targetdir undefined",
 			args:              []string{},
 			expectedSourceDir: defaultSourceDir,
+			expectedTargetDir: defaultTargetDir,
+		},
+		{
+			name:              "Cleans sourcedir of initial ./",
+			args:              []string{"--sourcedir", "./path/to/template"},
+			expectedSourceDir: filepath.Clean("path/to/template"),
 			expectedTargetDir: defaultTargetDir,
 		},
 	}


### PR DESCRIPTION
Bug summary:

`./` prepended to the beginning of a `--sourcedir` path causes issues
when building the package. The resulting package could not be installed.

The fix:

Clean the `sourceDir` string.